### PR TITLE
[WIP] Complete LLT, LDLT, MINRES, QRs, EigenSolver / Upgrade tests

### DIFF
--- a/include/nanoeigenpy/computation-info.hpp
+++ b/include/nanoeigenpy/computation-info.hpp
@@ -1,0 +1,23 @@
+/// Copyright 2025 INRIA
+#pragma once
+
+#include <nanobind/nanobind.h>
+#include <Eigen/Core>
+
+namespace nanoeigenpy {
+namespace nb = nanobind;
+inline void exposeComputationInfo(nb::module_ m) {
+  nb::enum_<Eigen::ComputationInfo>(m, "ComputationInfo")
+      .value("Success", Eigen::Success, 
+      "Computation was successful.") 
+      .value("NumericalIssue", Eigen::NumericalIssue,
+      "The provided data did not satisfy the prerequisites.") 
+      .value("NoConvergence", Eigen::NoConvergence,
+      "Iterative procedure did not converge.")
+      .value("InvalidInput", Eigen::InvalidInput,
+      "The inputs are invalid, or the algorithm has been improperly called. "
+      "When assertions are enabled, such errors trigger an assert.")
+      .export_values(); 
+}
+}  // namespace nanoeigenpy
+

--- a/include/nanoeigenpy/decompositions.hpp
+++ b/include/nanoeigenpy/decompositions.hpp
@@ -1,3 +1,4 @@
+/// Copyright 2025 INRIA
 #pragma once
 
 #include "nanoeigenpy/decompositions/llt.hpp"

--- a/include/nanoeigenpy/decompositions.hpp
+++ b/include/nanoeigenpy/decompositions.hpp
@@ -7,3 +7,4 @@
 #include "nanoeigenpy/decompositions/FullPivHouseholderQR.hpp"
 #include "nanoeigenpy/decompositions/ColPivHouseholderQR.hpp"
 #include "nanoeigenpy/decompositions/CompleteOrthogonalDecomposition.hpp"
+#include "nanoeigenpy/decompositions/EigenSolver.hpp"

--- a/include/nanoeigenpy/decompositions.hpp
+++ b/include/nanoeigenpy/decompositions.hpp
@@ -3,3 +3,7 @@
 #include "nanoeigenpy/decompositions/llt.hpp"
 #include "nanoeigenpy/decompositions/ldlt.hpp"
 #include "nanoeigenpy/decompositions/minres.hpp"
+#include "nanoeigenpy/decompositions/HouseholderQR.hpp"
+#include "nanoeigenpy/decompositions/FullPivHouseholderQR.hpp"
+#include "nanoeigenpy/decompositions/ColPivHouseholderQR.hpp"
+#include "nanoeigenpy/decompositions/CompleteOrthogonalDecomposition.hpp"

--- a/include/nanoeigenpy/decompositions/ColPivHouseholderQR.hpp
+++ b/include/nanoeigenpy/decompositions/ColPivHouseholderQR.hpp
@@ -140,10 +140,10 @@ void exposeColPivHouseholderQRSolver(nb::module_ m, const char *name) {
                 .def("matrixQR", &Solver::matrixQR,
                 "Returns the matrix where the Householder QR decomposition is "
                 "stored in a LAPACK-compatible way.",
-                nb::rv_policy::reference_internal) 
+                nb::rv_policy::copy) 
                 .def("matrixR", &Solver::matrixR,
                 "Returns the matrix where the result Householder QR is stored.",
-                nb::rv_policy::reference_internal)    
+                nb::rv_policy::copy) 
 
                 .def("compute",                                                                 
                     [](Solver &c, VectorType const &matrix) {
@@ -177,12 +177,3 @@ void exposeColPivHouseholderQRSolver(nb::module_ m, const char *name) {
 }
 
 }  // namespace nanoeigenpy
-
-// TODO
-
-// Tests that were not done in eigenpy that we could add in nanoeigenpy:
-// All that is not the basics
-
-// Expose supplementary content:
-
-// Technical 

--- a/include/nanoeigenpy/decompositions/ColPivHouseholderQR.hpp
+++ b/include/nanoeigenpy/decompositions/ColPivHouseholderQR.hpp
@@ -1,0 +1,188 @@
+/// Copyright 2025 INRIA
+#pragma once
+#include "base.hpp"
+#include <Eigen/QR>
+
+namespace nanoeigenpy {
+namespace nb = nanobind;
+
+template <typename MatrixType, typename MatrixOrVector>
+MatrixOrVector solve(const Eigen::ColPivHouseholderQR<MatrixType> &c, 
+                     const MatrixOrVector &vec) 
+{
+     return c.solve(vec);
+}
+
+template <typename MatrixType>
+MatrixType inverse(const Eigen::ColPivHouseholderQR<MatrixType> &c) 
+{
+     return c.inverse();
+}
+
+template <typename MatrixType>
+void exposeColPivHouseholderQRSolver(nb::module_ m, const char *name) {
+  using Solver = Eigen::ColPivHouseholderQR<MatrixType>;
+  using Scalar = typename MatrixType::Scalar;
+  using RealScalar = typename MatrixType::RealScalar;
+  using VectorType = Eigen::Matrix<Scalar, -1, 1>;
+  auto cl = nb::class_<Solver>(m, name, 
+                "This class performs a rank-revealing QR decomposition of a matrix A "
+                "into matrices P, Q and R such that:\n"
+                "AP=QR\n"
+                "by using Householder transformations. Here, P is a permutation "
+                "matrix, Q a unitary matrix and R an upper triangular matrix.\n"
+                "\n"
+                "This decomposition performs column pivoting in order to be "
+                "rank-revealing and improve numerical stability. It is slower than "
+                "HouseholderQR, and faster than FullPivHouseholderQR.")
+
+                .def(nb::init<>(),                                                              
+                "Default constructor.\n"
+                "The default constructor is useful in cases in which the "
+                "user intends to perform decompositions via "
+                "HouseholderQR.compute(matrix).")
+                .def(nb::init<Eigen::DenseIndex, Eigen::DenseIndex>(), 
+                 nb::arg("rows"), nb::arg("cols"),                       
+                "Default constructor with memory preallocation.\n"
+                "Like the default constructor but with preallocation of the "
+                "internal data according to the specified problem size. ")
+                .def(nb::init<const MatrixType &>(), nb::arg("matrix"),                   
+                "Constructs a QR factorization from a given matrix.\n"
+                "This constructor computes the QR factorization of the matrix "
+                "matrix by calling the method compute().")    
+
+                .def("info", &Solver::info,                                                       
+                "Reports whether the QR factorization was successful.\n"
+                "Note: This function always returns Success. It is provided for "
+                "compatibility with other factorization routines.")
+
+                .def("absDeterminant", &Solver::absDeterminant,
+                "Returns the absolute value of the determinant of the matrix of "
+                "which *this is the QR decomposition.\n"
+                "It has only linear complexity (that is, O(n) where n is the "
+                "dimension of the square matrix) as the QR decomposition has "
+                "already been computed.\n"
+                "Note: This is only for square matrices.")                                               
+                .def("logAbsDeterminant", &Solver::logAbsDeterminant,
+                "Returns the natural log of the absolute value of the determinant "
+                "of the matrix of which *this is the QR decomposition.\n"
+                "It has only linear complexity (that is, O(n) where n is the "
+                "dimension of the square matrix) as the QR decomposition has "
+                "already been computed.\n"
+                "Note: This is only for square matrices. This method is useful to "
+                "work around the risk of overflow/underflow that's inherent to "
+                "determinant computation.")  
+                .def("dimensionOfKernel", &Solver::dimensionOfKernel,
+                "Returns the dimension of the kernel of the matrix of which *this "
+                "is the QR decomposition.")  
+                .def("isInjective", &Solver::isInjective,
+                "Returns true if the matrix associated with this QR decomposition "
+                "represents an injective linear map, i.e. has trivial kernel; "
+                "false otherwise.\n"
+                "\n"
+                "Note: This method has to determine which pivots should be "
+                "considered nonzero. For that, it uses the threshold value that "
+                "you can control by calling setThreshold(threshold).")  
+                .def("isInvertible", &Solver::isInvertible,
+                "Returns true if the matrix associated with the QR decomposition "
+                "is invertible.\n"
+                "\n"
+                "Note: This method has to determine which pivots should be "
+                "considered nonzero. For that, it uses the threshold value that "
+                "you can control by calling setThreshold(threshold).")  
+                .def("isSurjective", &Solver::isSurjective,
+                "Returns true if the matrix associated with this QR decomposition "
+                "represents a surjective linear map; false otherwise.\n"
+                "\n"
+                "Note: This method has to determine which pivots should be "
+                "considered nonzero. For that, it uses the threshold value that "
+                "you can control by calling setThreshold(threshold).")  
+                .def("maxPivot", &Solver::maxPivot,
+                "Returns the absolute value of the biggest pivot, i.e. the "
+                "biggest diagonal coefficient of U.")  
+                .def("nonzeroPivots", &Solver::nonzeroPivots,
+                "Returns the number of nonzero pivots in the QR decomposition. "
+                "Here nonzero is meant in the exact sense, not in a fuzzy sense. "
+                "So that notion isn't really intrinsically interesting, but it is "
+                "still useful when implementing algorithms.")  
+                .def("rank", &Solver::rank,
+                "Returns the rank of the matrix associated with the QR "
+                "decomposition.\n"
+                "\n"
+                "Note: This method has to determine which pivots should be "
+                "considered nonzero. For that, it uses the threshold value that "
+                "you can control by calling setThreshold(threshold).")  
+
+                .def("setThreshold",
+                    [](Solver &c, RealScalar const &threshold) {
+                      return c.setThreshold(threshold);
+                    },
+                    nb::arg("threshold"), 
+                    "Allows to prescribe a threshold to be used by certain methods, "
+                    "such as rank(), who need to determine when pivots are to be "
+                    "considered nonzero. This is not used for the QR decomposition "
+                    "itself.\n"
+                    "\n"
+                    "When it needs to get the threshold value, Eigen calls "
+                    "threshold(). By default, this uses a formula to automatically "
+                    "determine a reasonable threshold. Once you have called the "
+                    "present method setThreshold(const RealScalar&), your value is "
+                    "used instead.\n"
+                    "\n"
+                    "Note: A pivot will be considered nonzero if its absolute value "
+                    "is strictly greater than |pivot| ⩽ threshold×|maxpivot| where "
+                    "maxpivot is the biggest pivot.",
+                    nb::rv_policy::reference)
+                .def("threshold", &Solver::threshold,
+                "Returns the threshold that will be used by certain methods such "
+                "as rank().")  
+
+                .def("matrixQR", &Solver::matrixQR,
+                "Returns the matrix where the Householder QR decomposition is "
+                "stored in a LAPACK-compatible way.",
+                nb::rv_policy::reference_internal) 
+                .def("matrixR", &Solver::matrixR,
+                "Returns the matrix where the result Householder QR is stored.",
+                nb::rv_policy::reference_internal)    
+
+                .def("compute",                                                                 
+                    [](Solver &c, VectorType const &matrix) {
+                      return c.compute(matrix);
+                    },
+                    nb::arg("matrix"),
+                    "Computes the QR factorization of given matrix.",
+                    nb::rv_policy::reference)     
+
+                .def("inverse",                                                                        
+                     [](Solver const &c) -> MatrixType { return inverse(c); },
+                     "Returns the inverse of the matrix associated with the QR "
+                     "decomposition.")       
+
+                .def("solve",                                                                        
+                     [](Solver const &c, VectorType const &b) -> VectorType { return solve(c, b); },
+                     nb::arg("b"),
+                     "Returns the solution x of A x = B using the current "
+                     "decomposition of A where b is a right hand side vector.")
+                .def("solve",                                                                        
+                     [](Solver const &c, MatrixType const &B) -> MatrixType { return solve(c, B); },
+                     nb::arg("B"),
+                     "Returns the solution X of A X = B using the current "
+                     "decomposition of A where B is a right hand side matrix.")                                          
+
+                .def("id",                                                                             
+                     [](Solver const &c) -> int64_t { return reinterpret_cast<int64_t>(&c); },
+                     "Returns the unique identity of an object.\n"
+                     "For objects held in C++, it corresponds to its memory address.");
+
+}
+
+}  // namespace nanoeigenpy
+
+// TODO
+
+// Tests that were not done in eigenpy that we could add in nanoeigenpy:
+// All that is not the basics
+
+// Expose supplementary content:
+
+// Technical 

--- a/include/nanoeigenpy/decompositions/CompleteOrthogonalDecomposition.hpp
+++ b/include/nanoeigenpy/decompositions/CompleteOrthogonalDecomposition.hpp
@@ -147,14 +147,13 @@ void exposeCompleteOrthogonalDecompositionSolver(nb::module_ m, const char *name
                 .def("matrixQTZ", &Solver::matrixQTZ,
                 "Returns the matrix where the complete orthogonal decomposition "
                 "is stored.",
-                nb::rv_policy::reference_internal) 
+                nb::rv_policy::copy) 
                 .def("matrixT", &Solver::matrixT,
                 "Returns the matrix where the complete orthogonal decomposition "
                 "is stored.",
-                nb::rv_policy::reference_internal) 
+                nb::rv_policy::copy) 
                 .def("matrixZ", &Solver::matrixZ,
-                "Returns the matrix Z.",
-                nb::rv_policy::reference_internal)    
+                "Returns the matrix Z.")
 
                 .def("compute",                                                                 
                     [](Solver &c, VectorType const &matrix) {

--- a/include/nanoeigenpy/decompositions/CompleteOrthogonalDecomposition.hpp
+++ b/include/nanoeigenpy/decompositions/CompleteOrthogonalDecomposition.hpp
@@ -1,0 +1,200 @@
+/// Copyright 2025 INRIA
+#pragma once
+#include "base.hpp"
+#include <Eigen/QR>
+
+namespace nanoeigenpy {
+namespace nb = nanobind;
+
+template <typename MatrixType, typename MatrixOrVector>
+MatrixOrVector solve(const Eigen::CompleteOrthogonalDecomposition<MatrixType> &c, 
+                     const MatrixOrVector &vec) 
+{
+     return c.solve(vec);
+}
+
+template <typename MatrixType>
+MatrixType pseudoInverse(const Eigen::CompleteOrthogonalDecomposition<MatrixType> &c) 
+{
+     return c.pseudoInverse();
+}
+
+template <typename MatrixType>
+void exposeCompleteOrthogonalDecompositionSolver(nb::module_ m, const char *name) {
+  using Solver = Eigen::CompleteOrthogonalDecomposition<MatrixType>;
+  using Scalar = typename MatrixType::Scalar;
+  using RealScalar = typename MatrixType::RealScalar;
+  using VectorType = Eigen::Matrix<Scalar, -1, 1>;
+  auto cl = nb::class_<Solver>(m, name, 
+                "This class performs a rank-revealing complete orthogonal "
+                "decomposition of a matrix A into matrices P, Q, T, and Z such that:\n"
+                "AP=Q[T000]Z"
+                "by using Householder transformations. Here, P is a permutation "
+                "matrix, Q and Z are unitary matrices and T an upper triangular matrix "
+                "of size rank-by-rank. A may be rank deficient.")
+
+                .def(nb::init<>(),                                                              
+                "Default constructor.\n"
+                "The default constructor is useful in cases in which the "
+                "user intends to perform decompositions via "
+                "HouseholderQR.compute(matrix).")
+                .def(nb::init<Eigen::DenseIndex, Eigen::DenseIndex>(), 
+                 nb::arg("rows"), nb::arg("cols"),                       
+                "Default constructor with memory preallocation.\n"
+                "Like the default constructor but with preallocation of the "
+                "internal data according to the specified problem size. ")
+                .def(nb::init<const MatrixType &>(), nb::arg("matrix"),                   
+                "Constructs a QR factorization from a given matrix.\n"
+                "This constructor computes the QR factorization of the matrix "
+                "matrix by calling the method compute().")    
+
+                .def("info", &Solver::info,                                                       
+                "Reports whether the complete orthogonal factorization was "
+                "successful.\n"
+                "Note: This function always returns Success. It is provided for "
+                "compatibility with other factorization routines.")
+
+                .def("absDeterminant", &Solver::absDeterminant,
+                "Returns the absolute value of the determinant of the matrix "
+                "associated with the complete orthogonal decomposition.\n"
+                "It has only linear complexity (that is, O(n) where n is the "
+                "dimension of the square matrix) as the complete orthogonal "
+                "decomposition has "
+                "already been computed.\n"
+                "Note: This is only for square matrices.")                                               
+                .def("logAbsDeterminant", &Solver::logAbsDeterminant,
+                "Returns the natural log of the absolute value of the determinant "
+                "of the matrix of which *this is the complete orthogonal "
+                "decomposition.\n"
+                "It has only linear complexity (that is, O(n) where n is the "
+                "dimension of the square matrix) as the complete orthogonal "
+                "decomposition has "
+                "already been computed.\n"
+                "Note: This is only for square matrices. This method is useful to "
+                "work around the risk of overflow/underflow that's inherent to "
+                "determinant computation.")  
+                .def("dimensionOfKernel", &Solver::dimensionOfKernel,
+                "Returns the dimension of the kernel of the matrix of which *this "
+                "is the complete orthogonal decomposition.")  
+                .def("isInjective", &Solver::isInjective,
+                "Returns true if the matrix associated with this complete "
+                "orthogonal decomposition "
+                "represents an injective linear map, i.e. has trivial kernel; "
+                "false otherwise.\n"
+                "\n"
+                "Note: This method has to determine which pivots should be "
+                "considered nonzero. For that, it uses the threshold value that "
+                "you can control by calling setThreshold(threshold).")  
+                .def("isInvertible", &Solver::isInvertible,
+                "Returns true if the matrix associated with the complete "
+                "orthogonal decomposition "
+                "is invertible.\n"
+                "\n"
+                "Note: This method has to determine which pivots should be "
+                "considered nonzero. For that, it uses the threshold value that "
+                "you can control by calling setThreshold(threshold).")  
+                .def("isSurjective", &Solver::isSurjective,
+                "Returns true if the matrix associated with this complete "
+                "orthogonal decomposition "
+                "represents a surjective linear map; false otherwise.\n"
+                "\n"
+                "Note: This method has to determine which pivots should be "
+                "considered nonzero. For that, it uses the threshold value that "
+                "you can control by calling setThreshold(threshold).")  
+                .def("maxPivot", &Solver::maxPivot,
+                "Returns the absolute value of the biggest pivot, i.e. the "
+                "biggest diagonal coefficient of U.")  
+                .def("nonzeroPivots", &Solver::nonzeroPivots,
+                "Returns the number of nonzero pivots in the complete orthogonal "
+                "decomposition. "
+                "Here nonzero is meant in the exact sense, not in a fuzzy sense. "
+                "So that notion isn't really intrinsically interesting, but it is "
+                "still useful when implementing algorithms.")  
+                .def("rank", &Solver::rank,
+                "Returns the rank of the matrix associated with the complete "
+                "orthogonal "
+                "decomposition.\n"
+                "\n"
+                "Note: This method has to determine which pivots should be "
+                "considered nonzero. For that, it uses the threshold value that "
+                "you can control by calling setThreshold(threshold).")  
+
+                .def("setThreshold",
+                    [](Solver &c, RealScalar const &threshold) {
+                      return c.setThreshold(threshold);
+                    },
+                    nb::arg("threshold"), 
+                    "Allows to prescribe a threshold to be used by certain methods, "
+                    "such as rank(), who need to determine when pivots are to be "
+                    "considered nonzero. This is not used for the complete orthogonal "
+                    "decomposition "
+                    "itself.\n"
+                    "\n"
+                    "When it needs to get the threshold value, Eigen calls "
+                    "threshold(). By default, this uses a formula to automatically "
+                    "determine a reasonable threshold. Once you have called the "
+                    "present method setThreshold(const RealScalar&), your value is "
+                    "used instead.\n"
+                    "\n"
+                    "Note: A pivot will be considered nonzero if its absolute value "
+                    "is strictly greater than |pivot| ⩽ threshold×|maxpivot| where "
+                    "maxpivot is the biggest pivot.",
+                    nb::rv_policy::reference)
+                .def("threshold", &Solver::threshold,
+                "Returns the threshold that will be used by certain methods such "
+                "as rank().")  
+
+                .def("matrixQTZ", &Solver::matrixQTZ,
+                "Returns the matrix where the complete orthogonal decomposition "
+                "is stored.",
+                nb::rv_policy::reference_internal) 
+                .def("matrixT", &Solver::matrixT,
+                "Returns the matrix where the complete orthogonal decomposition "
+                "is stored.",
+                nb::rv_policy::reference_internal) 
+                .def("matrixZ", &Solver::matrixZ,
+                "Returns the matrix Z.",
+                nb::rv_policy::reference_internal)    
+
+                .def("compute",                                                                 
+                    [](Solver &c, VectorType const &matrix) {
+                      return c.compute(matrix);
+                    },
+                    nb::arg("matrix"),
+                    "Computes the complete orthogonal factorization of given matrix.",
+                    nb::rv_policy::reference)     
+
+                .def("pseudoInverse",                                                                        
+                     [](Solver const &c) -> MatrixType { return pseudoInverse(c); },
+                     "Returns the pseudo-inverse of the matrix associated with the "
+                     "complete orthogonal "
+                     "decomposition.")       
+
+                .def("solve",                                                                        
+                     [](Solver const &c, VectorType const &b) -> VectorType { return solve(c, b); },
+                     nb::arg("b"),
+                     "Returns the solution x of A x = B using the current "
+                     "decomposition of A where b is a right hand side vector.")
+                .def("solve",                                                                        
+                     [](Solver const &c, MatrixType const &B) -> MatrixType { return solve(c, B); },
+                     nb::arg("B"),
+                     "Returns the solution X of A X = B using the current "
+                     "decomposition of A where B is a right hand side matrix.")                                          
+
+                .def("id",                                                                             
+                     [](Solver const &c) -> int64_t { return reinterpret_cast<int64_t>(&c); },
+                     "Returns the unique identity of an object.\n"
+                     "For objects held in C++, it corresponds to its memory address.");
+
+}
+
+}  // namespace nanoeigenpy
+
+// TODO
+
+// Tests that were not done in eigenpy that we could add in nanoeigenpy:
+// All that is not the basics
+
+// Expose supplementary content:
+
+// Technical 

--- a/include/nanoeigenpy/decompositions/EigenSolver.hpp
+++ b/include/nanoeigenpy/decompositions/EigenSolver.hpp
@@ -1,0 +1,89 @@
+/// Copyright 2025 INRIA
+#pragma once
+#include "base.hpp"
+// #include "nanoeigenpy/eigen-to-python.hpp"
+#include <Eigen/Core>
+#include <Eigen/Eigenvalues>
+#include <optional>
+
+namespace nanoeigenpy {
+namespace nb = nanobind;
+
+template <typename MatrixType>
+Eigen::EigenSolver<MatrixType>& compute_proxy(Eigen::EigenSolver<MatrixType> &c, 
+                                              const Eigen::EigenBase<MatrixType> &matrix) 
+{
+     return c.compute(matrix);
+}
+
+template <typename MatrixType>
+void exposeEigenSolver(nb::module_ m, const char *name) {
+  using Solver = Eigen::EigenSolver<MatrixType>;
+  auto cl = nb::class_<Solver>(m, name, "Eigen solver.")
+
+                .def(nb::init<>(), 
+                "Default constructor.")
+                .def(nb::init<Eigen::DenseIndex>(), nb::arg("size"), 
+                "Default constructor with memory preallocation.")
+                .def(nb::init<const MatrixType &, std::optional<bool>>(),  
+                    nb::arg("matrix"), 
+                    nb::arg("compute_eigen_vectors") = std::nullopt,  
+                    "Computes eigendecomposition of given matrix")
+
+                .def("eigenvalues", &Solver::eigenvalues,
+                "Returns the eigenvalues of given matrix.",
+                nb::rv_policy::reference_internal)                                               
+                .def("eigenvectors", &Solver::eigenvectors,
+                "Returns the eigenvectors of given matrix.")  
+
+                .def("compute",                                                                        
+                     [](Solver &c, Eigen::EigenBase<MatrixType> const &matrix) -> 
+                     Eigen::EigenBase<MatrixType> { return compute_proxy(c, matrix); },
+                     nb::arg("matrix"),
+                     "Computes the eigendecomposition of given matrix.",
+                     nb::rv_policy::reference)
+                .def("compute",                                                                 
+                    [](Solver &c, Eigen::EigenBase<MatrixType> const &matrix, bool compute_eigen_vectors) {
+                      return c.compute(matrix, compute_eigen_vectors);
+                    },
+                    nb::arg("matrix"), nb::arg("compute_eigen_vectors"),
+                     "Computes the eigendecomposition of given matrix.",
+                    nb::rv_policy::reference)
+
+                .def("getMaxIterations", &Solver::getMaxIterations,
+                "Returns the maximum number of iterations.")                                               
+                .def("setMaxIterations", &Solver::setMaxIterations,
+                "Sets the maximum number of iterations allowed.",
+                nb::rv_policy::reference)  
+
+                .def("pseudoEigenvalueMatrix", &Solver::pseudoEigenvalueMatrix,
+                "Returns the block-diagonal matrix in the "
+                "pseudo-eigendecomposition.")                                               
+                .def("pseudoEigenvectors", &Solver::pseudoEigenvectors,
+                "Returns the pseudo-eigenvectors of given matrix.",
+                nb::rv_policy::reference_internal)                                                
+                
+                .def("info", &Solver::info,                                                       
+                     "NumericalIssue if the input contains INF or NaN values or "
+                     "overflow occured. Returns Success otherwise.")
+
+                .def("id",                                                                             
+                     [](Solver const &c) -> int64_t { return reinterpret_cast<int64_t>(&c); },
+                     "Returns the unique identity of an object.\n"
+                     "For objects held in C++, it corresponds to its memory address.");
+
+}
+
+}  // namespace nanoeigenpy
+
+
+// TODO
+
+// Tests that were not done in eigenpy that we could add in nanoeigenpy: (+ those cited in llt.hpp)
+// 
+
+// Expose supplementary content:
+
+// Questions about eigenpy itself:
+// init with matrix: In their test, they init like with other decomps, but here in the .def,they add a second argument
+//    Check if my implem is correct

--- a/include/nanoeigenpy/decompositions/EigenSolver.hpp
+++ b/include/nanoeigenpy/decompositions/EigenSolver.hpp
@@ -25,9 +25,9 @@ void exposeEigenSolver(nb::module_ m, const char *name) {
                 "Default constructor.")
                 .def(nb::init<Eigen::DenseIndex>(), nb::arg("size"), 
                 "Default constructor with memory preallocation.")
-                .def(nb::init<const MatrixType &, std::optional<bool>>(),  
+                .def(nb::init<const MatrixType &, bool>(),  
                     nb::arg("matrix"), 
-                    nb::arg("compute_eigen_vectors") = std::nullopt,  
+                    nb::arg("compute_eigen_vectors") = true,  
                     "Computes eigendecomposition of given matrix")
 
                 .def("eigenvalues", &Solver::eigenvalues,
@@ -37,8 +37,8 @@ void exposeEigenSolver(nb::module_ m, const char *name) {
                 "Returns the eigenvectors of given matrix.")  
 
                 .def("compute",                                                                        
-                     [](Solver &c, Eigen::EigenBase<MatrixType> const &matrix) -> 
-                     Eigen::EigenBase<MatrixType> { return compute_proxy(c, matrix); },
+                     [](Solver &c, Eigen::EigenBase<MatrixType> const &matrix) -> Solver& 
+                     { return compute_proxy(c, matrix); },
                      nb::arg("matrix"),
                      "Computes the eigendecomposition of given matrix.",
                      nb::rv_policy::reference)
@@ -75,15 +75,3 @@ void exposeEigenSolver(nb::module_ m, const char *name) {
 }
 
 }  // namespace nanoeigenpy
-
-
-// TODO
-
-// Tests that were not done in eigenpy that we could add in nanoeigenpy: (+ those cited in llt.hpp)
-// 
-
-// Expose supplementary content:
-
-// Questions about eigenpy itself:
-// init with matrix: In their test, they init like with other decomps, but here in the .def,they add a second argument
-//    Check if my implem is correct

--- a/include/nanoeigenpy/decompositions/FullPivHouseholderQR.hpp
+++ b/include/nanoeigenpy/decompositions/FullPivHouseholderQR.hpp
@@ -136,7 +136,7 @@ void exposeFullPivHouseholderQRSolver(nb::module_ m, const char *name) {
                 .def("matrixQR", &Solver::matrixQR,
                 "Returns the matrix where the Householder QR decomposition is "
                 "stored in a LAPACK-compatible way.",
-                nb::rv_policy::reference_internal)    
+                nb::rv_policy::copy) 
 
                 .def("compute",                                                                 
                     [](Solver &c, VectorType const &matrix) {
@@ -170,14 +170,3 @@ void exposeFullPivHouseholderQRSolver(nb::module_ m, const char *name) {
 }
 
 }  // namespace nanoeigenpy
-
-// TODO
-
-// Tests that were not done in eigenpy that we could add in nanoeigenpy:
-// All that is not the basics
-
-// Expose supplementary content:
-// info ? exposed in colPivHouseholder par eg
-
-// Technical 
-// Why to repeat the .inverse() method ? Because in eigenpy, we litterally do function = function...

--- a/include/nanoeigenpy/decompositions/FullPivHouseholderQR.hpp
+++ b/include/nanoeigenpy/decompositions/FullPivHouseholderQR.hpp
@@ -1,0 +1,183 @@
+/// Copyright 2025 INRIA
+#pragma once
+#include "base.hpp"
+#include <Eigen/QR>
+
+namespace nanoeigenpy {
+namespace nb = nanobind;
+
+template <typename MatrixType, typename MatrixOrVector>
+MatrixOrVector solve(const Eigen::FullPivHouseholderQR<MatrixType> &c, 
+                     const MatrixOrVector &vec) 
+{
+     return c.solve(vec);
+}
+
+template <typename MatrixType>
+MatrixType inverse(const Eigen::FullPivHouseholderQR<MatrixType> &c) 
+{
+     return c.inverse();
+}
+
+template <typename MatrixType>
+void exposeFullPivHouseholderQRSolver(nb::module_ m, const char *name) {
+  using Solver = Eigen::FullPivHouseholderQR<MatrixType>;
+  using Scalar = typename MatrixType::Scalar;
+  using RealScalar = typename MatrixType::RealScalar;
+  using VectorType = Eigen::Matrix<Scalar, -1, 1>;
+  auto cl = nb::class_<Solver>(m, name, 
+                "This class performs a rank-revealing QR decomposition of a matrix A "
+                "into matrices P, P', Q and R such that:\n"
+                "PAP′=QR\n"
+                "by using Householder transformations. Here, P and P' are permutation "
+                "matrices, Q a unitary matrix and R an upper triangular matrix.\n"
+                "\n"
+                "This decomposition performs a very prudent full pivoting in order to "
+                "be rank-revealing and achieve optimal numerical stability. The "
+                "trade-off is that it is slower than HouseholderQR and "
+                "ColPivHouseholderQR.")
+
+                .def(nb::init<>(),                                                              
+                "Default constructor.\n"
+                "The default constructor is useful in cases in which the "
+                "user intends to perform decompositions via "
+                "HouseholderQR.compute(matrix).")
+                .def(nb::init<Eigen::DenseIndex, Eigen::DenseIndex>(), 
+                 nb::arg("rows"), nb::arg("cols"),                       
+                "Default constructor with memory preallocation.\n"
+                "Like the default constructor but with preallocation of the "
+                "internal data according to the specified problem size. ")
+                .def(nb::init<const MatrixType &>(), nb::arg("matrix"),                   
+                "Constructs a QR factorization from a given matrix.\n"
+                "This constructor computes the QR factorization of the matrix "
+                "matrix by calling the method compute().")    
+
+                .def("absDeterminant", &Solver::absDeterminant,
+                "Returns the absolute value of the determinant of the matrix of "
+                "which *this is the QR decomposition.\n"
+                "It has only linear complexity (that is, O(n) where n is the "
+                "dimension of the square matrix) as the QR decomposition has "
+                "already been computed.\n"
+                "Note: This is only for square matrices.")                                               
+                .def("logAbsDeterminant", &Solver::logAbsDeterminant,
+                "Returns the natural log of the absolute value of the determinant "
+                "of the matrix of which *this is the QR decomposition.\n"
+                "It has only linear complexity (that is, O(n) where n is the "
+                "dimension of the square matrix) as the QR decomposition has "
+                "already been computed.\n"
+                "Note: This is only for square matrices. This method is useful to "
+                "work around the risk of overflow/underflow that's inherent to "
+                "determinant computation.")  
+                .def("dimensionOfKernel", &Solver::dimensionOfKernel,
+                "Returns the dimension of the kernel of the matrix of which *this "
+                "is the QR decomposition.")  
+                .def("isInjective", &Solver::isInjective,
+                "Returns true if the matrix associated with this QR decomposition "
+                "represents an injective linear map, i.e. has trivial kernel; "
+                "false otherwise.\n"
+                "\n"
+                "Note: This method has to determine which pivots should be "
+                "considered nonzero. For that, it uses the threshold value that "
+                "you can control by calling setThreshold(threshold).")  
+                .def("isInvertible", &Solver::isInvertible,
+                "Returns true if the matrix associated with the QR decomposition "
+                "is invertible.\n"
+                "\n"
+                "Note: This method has to determine which pivots should be "
+                "considered nonzero. For that, it uses the threshold value that "
+                "you can control by calling setThreshold(threshold).")  
+                .def("isSurjective", &Solver::isSurjective,
+                "Returns true if the matrix associated with this QR decomposition "
+                "represents a surjective linear map; false otherwise.\n"
+                "\n"
+                "Note: This method has to determine which pivots should be "
+                "considered nonzero. For that, it uses the threshold value that "
+                "you can control by calling setThreshold(threshold).")  
+                .def("maxPivot", &Solver::maxPivot,
+                "Returns the absolute value of the biggest pivot, i.e. the "
+                "biggest diagonal coefficient of U.")  
+                .def("nonzeroPivots", &Solver::nonzeroPivots,
+                "Returns the number of nonzero pivots in the QR decomposition. "
+                "Here nonzero is meant in the exact sense, not in a fuzzy sense. "
+                "So that notion isn't really intrinsically interesting, but it is "
+                "still useful when implementing algorithms.")  
+                .def("rank", &Solver::rank,
+                "Returns the rank of the matrix associated with the QR "
+                "decomposition.\n"
+                "\n"
+                "Note: This method has to determine which pivots should be "
+                "considered nonzero. For that, it uses the threshold value that "
+                "you can control by calling setThreshold(threshold).")  
+
+                .def("setThreshold",
+                    [](Solver &c, RealScalar const &threshold) {
+                      return c.setThreshold(threshold);
+                    },
+                    nb::arg("threshold"), 
+                    "Allows to prescribe a threshold to be used by certain methods, "
+                    "such as rank(), who need to determine when pivots are to be "
+                    "considered nonzero. This is not used for the QR decomposition "
+                    "itself.\n"
+                    "\n"
+                    "When it needs to get the threshold value, Eigen calls "
+                    "threshold(). By default, this uses a formula to automatically "
+                    "determine a reasonable threshold. Once you have called the "
+                    "present method setThreshold(const RealScalar&), your value is "
+                    "used instead.\n"
+                    "\n"
+                    "Note: A pivot will be considered nonzero if its absolute value "
+                    "is strictly greater than |pivot| ⩽ threshold×|maxpivot| where "
+                    "maxpivot is the biggest pivot.",
+                    nb::rv_policy::reference)
+                .def("threshold", &Solver::threshold,
+                "Returns the threshold that will be used by certain methods such "
+                "as rank().")  
+
+                .def("matrixQR", &Solver::matrixQR,
+                "Returns the matrix where the Householder QR decomposition is "
+                "stored in a LAPACK-compatible way.",
+                nb::rv_policy::reference_internal)    
+
+                .def("compute",                                                                 
+                    [](Solver &c, VectorType const &matrix) {
+                      return c.compute(matrix);
+                    },
+                    nb::arg("matrix"),
+                    "Computes the QR factorization of given matrix.",
+                    nb::rv_policy::reference)     
+
+                .def("inverse",                                                                        
+                     [](Solver const &c) -> MatrixType { return inverse(c); },
+                     "Returns the inverse of the matrix associated with the QR "
+                     "decomposition.")       
+
+                .def("solve",                                                                        
+                     [](Solver const &c, VectorType const &b) -> VectorType { return solve(c, b); },
+                     nb::arg("b"),
+                     "Returns the solution x of A x = B using the current "
+                     "decomposition of A where b is a right hand side vector.")
+                .def("solve",                                                                        
+                     [](Solver const &c, MatrixType const &B) -> MatrixType { return solve(c, B); },
+                     nb::arg("B"),
+                     "Returns the solution X of A X = B using the current "
+                     "decomposition of A where B is a right hand side matrix.")                                          
+
+                .def("id",                                                                             
+                     [](Solver const &c) -> int64_t { return reinterpret_cast<int64_t>(&c); },
+                     "Returns the unique identity of an object.\n"
+                     "For objects held in C++, it corresponds to its memory address.");
+
+}
+
+}  // namespace nanoeigenpy
+
+// TODO
+
+// Tests that were not done in eigenpy that we could add in nanoeigenpy:
+// All that is not the basics
+
+// Expose supplementary content:
+// info ? exposed in colPivHouseholder par eg
+
+// Technical 
+// Why to repeat the .inverse() method ? Because in eigenpy, we litterally do function = function...

--- a/include/nanoeigenpy/decompositions/HouseholderQR.hpp
+++ b/include/nanoeigenpy/decompositions/HouseholderQR.hpp
@@ -64,10 +64,15 @@ void exposeHouseholderQRSolver(nb::module_ m, const char *name) {
                 "work around the risk of overflow/underflow that's inherent to "
                 "determinant computation.")  
 
+                .def("householderQ", &Solver::matrixQR,
+                "Returns the matrix where the Householder QR decomposition is "
+                "stored in a LAPACK-compatible way.",
+                nb::rv_policy::copy) 
+
                 .def("matrixQR", &Solver::matrixQR,
                 "Returns the matrix where the Householder QR decomposition is "
                 "stored in a LAPACK-compatible way.",
-                nb::rv_policy::reference_internal)    
+                nb::rv_policy::copy) 
 
                 .def("compute",                                                                 
                     [](Solver &c, VectorType const &matrix) {
@@ -96,16 +101,3 @@ void exposeHouseholderQRSolver(nb::module_ m, const char *name) {
 }
 
 }  // namespace nanoeigenpy
-
-
-// TODO
-
-// Tests that were not done in eigenpy that we could add in nanoeigenpy:
-
-// Expose supplementary content:
-// init with mem prealoc with the sizes: check why it is different from the others with one arg instead of 2
-// No EigenBaseVisitor ? 
-// Add others ? Like info, or specific methods ? 
-
-// Technical 
-// See exactly what rv_policy I should use according to different cases (eg for matrixQR and others)

--- a/include/nanoeigenpy/decompositions/HouseholderQR.hpp
+++ b/include/nanoeigenpy/decompositions/HouseholderQR.hpp
@@ -1,0 +1,111 @@
+/// Copyright 2025 INRIA
+#pragma once
+#include "base.hpp"
+#include <Eigen/QR>
+
+namespace nanoeigenpy {
+namespace nb = nanobind;
+
+template <typename MatrixType, typename MatrixOrVector>
+MatrixOrVector solve(const Eigen::HouseholderQR<MatrixType> &c, 
+                     const MatrixOrVector &vec) 
+{
+     return c.solve(vec);
+}
+
+template <typename MatrixType>
+void exposeHouseholderQRSolver(nb::module_ m, const char *name) {
+  using Solver = Eigen::HouseholderQR<MatrixType>;
+  using Scalar = typename MatrixType::Scalar;
+  using VectorType = Eigen::Matrix<Scalar, -1, 1>;
+  auto cl = nb::class_<Solver>(m, name, 
+                "This class performs a QR decomposition of a matrix A into matrices Q "
+                "and R such that A=QR by using Householder transformations.\n"
+                "Here, Q a unitary matrix and R an upper triangular matrix. The result "
+                "is stored in a compact way compatible with LAPACK.\n"
+                "\n"
+                "Note that no pivoting is performed. This is not a rank-revealing "
+                "decomposition. If you want that feature, use FullPivHouseholderQR or "
+                "ColPivHouseholderQR instead.\n"
+                "\n"
+                "This Householder QR decomposition is faster, but less numerically "
+                "stable and less feature-full than FullPivHouseholderQR or "
+                "ColPivHouseholderQR.")
+
+                .def(nb::init<>(),                                                              
+                "Default constructor.\n"
+                "The default constructor is useful in cases in which the "
+                "user intends to perform decompositions via "
+                "HouseholderQR.compute(matrix).")
+                .def(nb::init<Eigen::DenseIndex, Eigen::DenseIndex>(), 
+                 nb::arg("rows"), nb::arg("cols"),                       
+                "Default constructor with memory preallocation.\n"
+                "Like the default constructor but with preallocation of the "
+                "internal data according to the specified problem size. ")
+                .def(nb::init<const MatrixType &>(), nb::arg("matrix"),                   
+                "Constructs a QR factorization from a given matrix.\n"
+                "This constructor computes the QR factorization of the matrix "
+                "matrix by calling the method compute().")    
+
+                .def("absDeterminant", &Solver::absDeterminant,
+                "Returns the absolute value of the determinant of the matrix of "
+                "which *this is the QR decomposition.\n"
+                "It has only linear complexity (that is, O(n) where n is the "
+                "dimension of the square matrix) as the QR decomposition has "
+                "already been computed.\n"
+                "Note: This is only for square matrices.")                                               
+                .def("logAbsDeterminant", &Solver::logAbsDeterminant,
+                "Returns the natural log of the absolute value of the determinant "
+                "of the matrix of which *this is the QR decomposition.\n"
+                "It has only linear complexity (that is, O(n) where n is the "
+                "dimension of the square matrix) as the QR decomposition has "
+                "already been computed.\n"
+                "Note: This is only for square matrices. This method is useful to "
+                "work around the risk of overflow/underflow that's inherent to "
+                "determinant computation.")  
+
+                .def("matrixQR", &Solver::matrixQR,
+                "Returns the matrix where the Householder QR decomposition is "
+                "stored in a LAPACK-compatible way.",
+                nb::rv_policy::reference_internal)    
+
+                .def("compute",                                                                 
+                    [](Solver &c, VectorType const &matrix) {
+                      return c.compute(matrix);
+                    },
+                    nb::arg("matrix"),
+                    "Computes the QR factorization of given matrix.",
+                    nb::rv_policy::reference)    
+
+                .def("solve",                                                                        
+                     [](Solver const &c, VectorType const &b) -> VectorType { return solve(c, b); },
+                     nb::arg("b"),
+                     "Returns the solution x of A x = B using the current "
+                     "decomposition of A where b is a right hand side vector.")
+                .def("solve",                                                                        
+                     [](Solver const &c, MatrixType const &B) -> MatrixType { return solve(c, B); },
+                     nb::arg("B"),
+                     "Returns the solution X of A X = B using the current "
+                     "decomposition of A where B is a right hand side matrix.")                                          
+
+                .def("id",                                                                             
+                     [](Solver const &c) -> int64_t { return reinterpret_cast<int64_t>(&c); },
+                     "Returns the unique identity of an object.\n"
+                     "For objects held in C++, it corresponds to its memory address.");
+
+}
+
+}  // namespace nanoeigenpy
+
+
+// TODO
+
+// Tests that were not done in eigenpy that we could add in nanoeigenpy:
+
+// Expose supplementary content:
+// init with mem prealoc with the sizes: check why it is different from the others with one arg instead of 2
+// No EigenBaseVisitor ? 
+// Add others ? Like info, or specific methods ? 
+
+// Technical 
+// See exactly what rv_policy I should use according to different cases (eg for matrixQR and others)

--- a/include/nanoeigenpy/decompositions/ldlt.hpp
+++ b/include/nanoeigenpy/decompositions/ldlt.hpp
@@ -52,7 +52,8 @@ void exposeLDLTSolver(nb::module_ m, const char *name) {
                      [](Solver const &c) -> VectorType { return c.vectorD(); },
                      "Returns the coefficients of the diagonal matrix D.")
                 .def("matrixLDLT", &Solver::matrixLDLT,
-                     "Returns the LDLT decomposition matrix.",
+                     "Returns the LDLT decomposition matrix made of the lower matrix "
+                     "L, the diagonal D, then the remaining part that corresponds to A.",
                      nb::rv_policy::reference_internal)
 
                 .def("transpositionsP",
@@ -64,6 +65,7 @@ void exposeLDLTSolver(nb::module_ m, const char *name) {
                     [](Solver &c, VectorType const &w, Scalar sigma) {
                       return c.rankUpdate(w, sigma);
                     },
+                    "If LDL^* = A, then it becomes A + sigma * v v^*",
                     nb::arg("w"), nb::arg("sigma"))
 
 #if EIGEN_VERSION_AT_LEAST(3, 3, 0)
@@ -117,16 +119,3 @@ void exposeLDLTSolver(nb::module_ m, const char *name) {
 }
 
 }  // namespace nanoeigenpy
-
-
-// TODO
-
-// Tests that were not done in eigenpy that we could add in nanoeigenpy: (+ those cited in llt.hpp)
-// setZero
-
-// Expose supplementary content:
-// setZero in LLT decomp too ? (not done in eigenpy)
-
-// Questions about eigenpy itself:
-// Relevant to have the reconstructedMatrix method ? (knowing that we are on LDLT, not LLT)
-// Review again the ways I use the Matrix... and Vector... in the using, .def(), etc (quite confusing)

--- a/include/nanoeigenpy/decompositions/ldlt.hpp
+++ b/include/nanoeigenpy/decompositions/ldlt.hpp
@@ -129,3 +129,4 @@ void exposeLDLTSolver(nb::module_ m, const char *name) {
 
 // Questions about eigenpy itself:
 // Relevant to have the reconstructedMatrix method ? (knowing that we are on LDLT, not LLT)
+// Review again the ways I use the Matrix... and Vector... in the using, .def(), etc (quite confusing)

--- a/include/nanoeigenpy/decompositions/llt.hpp
+++ b/include/nanoeigenpy/decompositions/llt.hpp
@@ -132,3 +132,8 @@ void exposeLLTSolver(nb::module_ m, const char *name) {
 
 // Assertions for the solve method on vectors x_est and b
 // Expose is_approx for vectors too (exposed and tested for ùatrices only in eigenpy)
+
+// In general in the lib
+// Calls for MatrixXs, VectorXs insead of Matrix and Vector defined one more time ? 
+//   For the moment, my implem works, but the code is a bit dirty
+// Check if the rv_policy are well chosen (compare with the eigenpy code)

--- a/include/nanoeigenpy/decompositions/llt.hpp
+++ b/include/nanoeigenpy/decompositions/llt.hpp
@@ -47,7 +47,8 @@ void exposeLLTSolver(nb::module_ m, const char *name) {
                      [](Chol const &c) -> MatrixType { return c.matrixU(); },
                      "Returns the upper triangular matrix U.")
                 .def("matrixLLT", &Chol::matrixLLT,                                             
-                     "Returns the LLT decomposition matrix.",
+                     "Returns the LLT decomposition matrix made of the lower matrix "
+                     "L, plus the remaining part that corresponds to A.",
                      nb::rv_policy::reference_internal)
 
 #if EIGEN_VERSION_AT_LEAST(3, 3, 90)               
@@ -55,6 +56,7 @@ void exposeLLTSolver(nb::module_ m, const char *name) {
                     [](Chol &c, VectorType const &w, Scalar sigma) {
                       return c.rankUpdate(w, sigma);
                     },
+                    "If LL^* = A, then it becomes A + sigma * v v^*",
                     nb::arg("w"), nb::arg("sigma"),                          
                     nb::rv_policy::reference)
 #else
@@ -62,6 +64,7 @@ void exposeLLTSolver(nb::module_ m, const char *name) {
                     [](Chol &c, VectorType const &w, Scalar sigma) {
                       return c.rankUpdate(w, sigma);
                     },
+                    "If LL^* = A, then it becomes A + sigma * v v^*",
                     nb::arg("w"), nb::arg("sigma"))
 #endif
 
@@ -113,27 +116,3 @@ void exposeLLTSolver(nb::module_ m, const char *name) {
 }
 
 }  // namespace nanoeigenpy
-
-
-// TODO
-
-// Tests that were not done in eigenpy that we could add in nanoeigenpy:
-// Default constructor
-// Default constructor with memory preallocation
-// matrixLLT
-// rankUpdate
-// adjoint
-// compute
-// rcond
-// reconstructedMatrix
-
-// Expose supplementary content:
-// Expose ComputationInfo to test info
-
-// Assertions for the solve method on vectors x_est and b
-// Expose is_approx for vectors too (exposed and tested for ùatrices only in eigenpy)
-
-// In general in the lib
-// Calls for MatrixXs, VectorXs insead of Matrix and Vector defined one more time ? 
-//   For the moment, my implem works, but the code is a bit dirty
-// Check if the rv_policy are well chosen (compare with the eigenpy code)

--- a/include/nanoeigenpy/decompositions/minres.hpp
+++ b/include/nanoeigenpy/decompositions/minres.hpp
@@ -164,9 +164,5 @@ void exposeMINRESSolver(nb::module_ m, const char *name) {
 // solve for vector and matrix
 // solveWithGuess for vector and matrix
 
-// Expose supplementary content:
-// Do the init with size argument ?
-// Do EigenBaseVisitor ? 
-// Ambiguity in the definition of info between LLT/LDLT and MINRES (still have to expose ComputationInfo)
-// In general, it seems that some methods are in some decomps, but not in others, while them seem to be quite general 
-// (eg some solve, init, etc methods)
+// Error
+// solve test do not pass

--- a/include/nanoeigenpy/decompositions/minres.hpp
+++ b/include/nanoeigenpy/decompositions/minres.hpp
@@ -170,6 +170,3 @@ void exposeMINRESSolver(nb::module_ m, const char *name) {
 // Ambiguity in the definition of info between LLT/LDLT and MINRES (still have to expose ComputationInfo)
 // In general, it seems that some methods are in some decomps, but not in others, while them seem to be quite general 
 // (eg some solve, init, etc methods)
-
-// Technical specificities
-// MINRES has a destructor ~MINRES, but not LLT and LDLT -> errors when make install -> adapt the code

--- a/include/nanoeigenpy/geometry/angle-axis.hpp
+++ b/include/nanoeigenpy/geometry/angle-axis.hpp
@@ -3,27 +3,68 @@
 #include "detail/rotation-base.hpp"
 
 namespace nanoeigenpy {
+namespace nb = nanobind;
 
 template <typename Scalar>
-void exposeAngleAxis(nb::module_ &m, const char *name) {
+bool isApprox(const Eigen::AngleAxis<Scalar> &aa, 
+           const Eigen::AngleAxis<Scalar> &other,
+           const Scalar &prec = Eigen::NumTraits<Scalar>::dummy_precision()) 
+{
+     return aa.isApprox(other, prec);
+}
+
+template <typename Scalar>
+void exposeAngleAxis(nb::module_ m, const char *name) {
   using namespace nb::literals;
   using AngleAxis = Eigen::AngleAxis<Scalar>;
   using Quat = typename AngleAxis::QuaternionType;
   using Vector3 = typename AngleAxis::Vector3;
   using Matrix3 = typename AngleAxis::Matrix3;
 
-  nb::class_<AngleAxis>(m, name)
-      .def(nb::init<>())
-      .def(nb::init<const Scalar &, Vector3>(), "angle"_a, "axis"_a)
-      .def(nb::init<Quat>(), "q"_a)
-      .def(nb::init<Matrix3>(), "R"_a)
-      .def_prop_rw(
-          "angle", [](const AngleAxis &aa) { return aa.angle(); },
-          [](AngleAxis &aa, Scalar a) { aa.angle() = a; })
-      .def_prop_rw(
-          "axis", [](const AngleAxis &aa) { return aa.axis(); },
-          [](AngleAxis &aa, const Vector3 &v) { aa.axis() = v; })
-      .def(RotationBaseVisitor<AngleAxis, 3>());
+  auto cl = nb::class_<AngleAxis>(m, name, 
+            "AngleAxis representation of a rotation.\n\n")
+
+            .def(nb::init<>(),
+            "Default constructor")
+            .def(nb::init<const Scalar &, Vector3>(), 
+            nb::arg("angle"), nb::arg("axis"), 
+                "Initialize from angle and axis.")
+            .def(nb::init<Matrix3>(), 
+            nb::arg("R"),
+            "Initialize from a rotation matrix.")
+            .def(nb::init<Quat>(), 
+            nb::arg("quaternion"),
+            "Initialize from a quaternion.")
+            .def(nb::init<AngleAxis>(), 
+            nb::arg("copy"),
+            "Copy constructor.")
+
+            
+            .def_prop_rw(
+                "angle", [](const AngleAxis &aa) { return aa.angle(); },
+                [](AngleAxis &aa, Scalar a) { aa.angle() = a; },
+                "The rotation angle.", 
+                nb::rv_policy::reference_internal)
+            .def_prop_rw(
+                "axis", [](const AngleAxis &aa) { return aa.axis(); },
+                [](AngleAxis &aa, const Vector3 &v) { aa.axis() = v; },
+                "The rotation axis.")
+
+            .def(RotationBaseVisitor<AngleAxis, 3>())
+            .def("fromRotationMatrix",
+                &AngleAxis::template fromRotationMatrix<Matrix3>,
+                nb::arg("self"), nb::arg("rotation matrix"),
+                "Sets *this from a 3x3 rotation matrix", 
+                nb::rv_policy::reference_internal)
+
+            .def("isApprox",                                                                        
+                [](const AngleAxis &aa, const AngleAxis &other, const Scalar &prec) 
+                -> bool { return isApprox(aa, other, prec); },
+                nb::arg("other"), nb::arg("rec"),
+                "Returns true if *this is approximately equal to other, "
+                "within the precision determined by prec.")
+
+            .def(nb::self * nb::other<Vector3>());
 }
 
 }  // namespace nanoeigenpy

--- a/include/nanoeigenpy/utils/is-approx.hpp
+++ b/include/nanoeigenpy/utils/is-approx.hpp
@@ -10,36 +10,36 @@
 
 namespace nanoeigenpy {
 
-template <typename MatrixType1, typename MatrixType2>
-EIGEN_DONT_INLINE bool is_approx(const Eigen::MatrixBase<MatrixType1>& mat1,
-                                 const Eigen::MatrixBase<MatrixType2>& mat2,
-                                 const typename MatrixType1::RealScalar& prec) {
+template <typename MatrixOrVectorType1, typename MatrixOrVectorType2>
+EIGEN_DONT_INLINE bool is_approx(const Eigen::MatrixBase<MatrixOrVectorType1>& mat1,
+                                 const Eigen::MatrixBase<MatrixOrVectorType2>& mat2,
+                                 const typename MatrixOrVectorType1::RealScalar& prec) {
   return mat1.isApprox(mat2, prec);
 }
 
-template <typename MatrixType1, typename MatrixType2>
-EIGEN_DONT_INLINE bool is_approx(const Eigen::MatrixBase<MatrixType1>& mat1,
-                                 const Eigen::MatrixBase<MatrixType2>& mat2) {
+template <typename MatrixOrVectorType1, typename MatrixOrVectorType2>
+EIGEN_DONT_INLINE bool is_approx(const Eigen::MatrixBase<MatrixOrVectorType1>& mat1,
+                                 const Eigen::MatrixBase<MatrixOrVectorType2>& mat2) {
   return is_approx(
       mat1, mat2,
-      Eigen::NumTraits<typename MatrixType1::RealScalar>::dummy_precision());
+      Eigen::NumTraits<typename MatrixOrVectorType1::RealScalar>::dummy_precision());
 }
 
-template <typename MatrixType1, typename MatrixType2>
+template <typename MatrixOrVectorType1, typename MatrixOrVectorType2>
 EIGEN_DONT_INLINE bool is_approx(
-    const Eigen::SparseMatrixBase<MatrixType1>& mat1,
-    const Eigen::SparseMatrixBase<MatrixType2>& mat2,
-    const typename MatrixType1::RealScalar& prec) {
+    const Eigen::SparseMatrixBase<MatrixOrVectorType1>& mat1,
+    const Eigen::SparseMatrixBase<MatrixOrVectorType2>& mat2,
+    const typename MatrixOrVectorType1::RealScalar& prec) {
   return mat1.isApprox(mat2, prec);
 }
 
-template <typename MatrixType1, typename MatrixType2>
+template <typename MatrixOrVectorType1, typename MatrixOrVectorType2>
 EIGEN_DONT_INLINE bool is_approx(
-    const Eigen::SparseMatrixBase<MatrixType1>& mat1,
-    const Eigen::SparseMatrixBase<MatrixType2>& mat2) {
+    const Eigen::SparseMatrixBase<MatrixOrVectorType1>& mat1,
+    const Eigen::SparseMatrixBase<MatrixOrVectorType2>& mat2) {
   return is_approx(
       mat1, mat2,
-      Eigen::NumTraits<typename MatrixType1::RealScalar>::dummy_precision());
+      Eigen::NumTraits<typename MatrixOrVectorType1::RealScalar>::dummy_precision());
 }
 
 namespace nb = nanobind;
@@ -48,7 +48,6 @@ template <typename Scalar>
 void exposeIsApprox(nb::module_ m) {
     enum { Options = 0 };
     NANOEIGENPY_MAKE_TYPEDEFS(Scalar, Options, s, Eigen::Dynamic, X);
-    NANOEIGENPY_UNUSED_TYPE(VectorXs);
     NANOEIGENPY_UNUSED_TYPE(RowVectorXs);
     typedef typename MatrixXs::RealScalar RealScalar;
 
@@ -56,7 +55,7 @@ void exposeIsApprox(nb::module_ m) {
     const RealScalar dummy_precision =
         Eigen::NumTraits<RealScalar>::dummy_precision();
 
-    // Exposition de la fonction is_approx pour matrices denses
+    // is_approx for dense matrices
     m.def("is_approx",
           [](const MatrixXs& mat1, const MatrixXs& mat2, RealScalar precision) {
               return is_approx(mat1, mat2, precision);
@@ -64,6 +63,15 @@ void exposeIsApprox(nb::module_ m) {
           nb::arg("mat1"), nb::arg("mat2"),
           nb::arg("precision") = dummy_precision,
           "Check if two dense matrices are approximately equal.");
+
+    // is_approx for dense vectors
+    m.def("is_approx",
+          [](const VectorXs& vec1, const VectorXs& vec2, RealScalar precision) {
+              return is_approx(vec1, vec2, precision);
+          },
+          nb::arg("vec1"), nb::arg("vec2"),
+          nb::arg("precision") = dummy_precision,
+          "Check if two dense vectors are approximately equal.");
 }
 
 }  // namespace nanoeigenpy

--- a/src/module.cpp
+++ b/src/module.cpp
@@ -5,6 +5,7 @@
 #include "nanoeigenpy/decompositions.hpp"
 #include "nanoeigenpy/geometry.hpp"
 #include "nanoeigenpy/utils/is-approx.hpp"
+#include "nanoeigenpy/computation-info.hpp"
 
 using namespace nanoeigenpy;
 
@@ -30,7 +31,7 @@ NB_MODULE(nanoeigenpy, m) {
   exposeFullPivHouseholderQRSolver<Matrix>(m, "FullPivHouseholderQR");
   exposeColPivHouseholderQRSolver<Matrix>(m, "ColPivHouseholderQR");
   exposeCompleteOrthogonalDecompositionSolver<Matrix>(m, "CompleteOrthogonalDecomposition");
-  exposeEigenSolver<Matrix>(m, "exposeEigenSolver");
+  exposeEigenSolver<Matrix>(m, "EigenSolver");
 
   // Geometry
   exposeQuaternion<Scalar>(m, "Quaternion");
@@ -39,21 +40,6 @@ NB_MODULE(nanoeigenpy, m) {
   // Utils
   exposeIsApprox<double>(m);
   exposeIsApprox<std::complex<double>>(m);
+
+  exposeComputationInfo(m);
 }
-
-
-// Meeting Mar 11 - About nanoeigenpy
-
-// In eigenpy, there are decompositions, solvers, geometry stuff, etc
-// -> I focused on some decompositions first: LLT, LDLT, MINRES, QR, EigenSolver
-
-// What I did:
-// 1. Translated the Bosst.Python classes of visitors into nanobind classes in expose functions
-// 2. Passed the same tests as those in eigenpy
-
-// TODO: 
-// 1. Finish to expose decompositions and geometry stuff
-// 2. Upgrade the unit tests to all the methods (defined in .def() so that they are more complete)
-// 3. Additional content from eigenpy (eg the diferent solvers, etc)
-// (2 <-> 3 ?)
-

--- a/src/module.cpp
+++ b/src/module.cpp
@@ -16,17 +16,21 @@ using Quaternion = Eigen::Quaternion<Scalar, Options>;
 
 NB_MAKE_OPAQUE(Eigen::LLT<Eigen::MatrixXd>)
 NB_MAKE_OPAQUE(Eigen::LDLT<Eigen::MatrixXd>)
-// TODO: Same for geometry stuff ?
+NB_MAKE_OPAQUE(Eigen::HouseholderQR<Eigen::MatrixXd>)
+NB_MAKE_OPAQUE(Eigen::FullPivHouseholderQR<Eigen::MatrixXd>)
+NB_MAKE_OPAQUE(Eigen::ColPivHouseholderQR<Eigen::MatrixXd>)
+NB_MAKE_OPAQUE(Eigen::CompleteOrthogonalDecomposition<Eigen::MatrixXd>)
 
 NB_MODULE(nanoeigenpy, m) {
   // Decompositions
   exposeLLTSolver<Matrix>(m, "LLT");
   exposeLDLTSolver<Matrix>(m, "LDLT");
   exposeMINRESSolver<Matrix>(m, "MINRES");
-  // exposeHouseholderQRSolver<Matrix>(m, "HouseholderQR");
-  // exposeFullPivHouseholderQRSolver<Matrix>(m, "FullPivHouseholderQR")
-  // exposeColPivHouseholderQRSolver<Matrix>(m, "ColPivHouseholderQR")
-  // exposeCompleteOrthogonalDecompositionSolver<Matrix>(m, "CompleteOrthogonalDecomposition")
+  exposeHouseholderQRSolver<Matrix>(m, "HouseholderQR");
+  exposeFullPivHouseholderQRSolver<Matrix>(m, "FullPivHouseholderQR");
+  exposeColPivHouseholderQRSolver<Matrix>(m, "ColPivHouseholderQR");
+  exposeCompleteOrthogonalDecompositionSolver<Matrix>(m, "CompleteOrthogonalDecomposition");
+  exposeEigenSolver<Matrix>(m, "exposeEigenSolver");
 
   // Geometry
   exposeQuaternion<Scalar>(m, "Quaternion");
@@ -36,3 +40,20 @@ NB_MODULE(nanoeigenpy, m) {
   exposeIsApprox<double>(m);
   exposeIsApprox<std::complex<double>>(m);
 }
+
+
+// Meeting Mar 11 - About nanoeigenpy
+
+// In eigenpy, there are decompositions, solvers, geometry stuff, etc
+// -> I focused on some decompositions first: LLT, LDLT, MINRES, QR, EigenSolver
+
+// What I did:
+// 1. Translated the Bosst.Python classes of visitors into nanobind classes in expose functions
+// 2. Passed the same tests as those in eigenpy
+
+// TODO: 
+// 1. Finish to expose decompositions and geometry stuff
+// 2. Upgrade the unit tests to all the methods (defined in .def() so that they are more complete)
+// 3. Additional content from eigenpy (eg the diferent solvers, etc)
+// (2 <-> 3 ?)
+

--- a/src/module.cpp
+++ b/src/module.cpp
@@ -23,6 +23,10 @@ NB_MODULE(nanoeigenpy, m) {
   exposeLLTSolver<Matrix>(m, "LLT");
   exposeLDLTSolver<Matrix>(m, "LDLT");
   exposeMINRESSolver<Matrix>(m, "MINRES");
+  // exposeHouseholderQRSolver<Matrix>(m, "HouseholderQR");
+  // exposeFullPivHouseholderQRSolver<Matrix>(m, "FullPivHouseholderQR")
+  // exposeColPivHouseholderQRSolver<Matrix>(m, "ColPivHouseholderQR")
+  // exposeCompleteOrthogonalDecompositionSolver<Matrix>(m, "CompleteOrthogonalDecomposition")
 
   // Geometry
   exposeQuaternion<Scalar>(m, "Quaternion");

--- a/tests/python/test_QR.py
+++ b/tests/python/test_QR.py
@@ -20,12 +20,20 @@ assert householder_qr_eye.logAbsDeterminant() == 0.0
 Y = householder_qr_eye.solve(X)
 assert (X == Y).all()
 
+x = rng.random(rows)
+y = householder_qr_eye.solve(x)
+assert (x == y).all()
+
 # Test FullPivHouseholderQR decomposition
 fullpiv_householder_qr = nanoeigenpy.FullPivHouseholderQR()
 fullpiv_householder_qr = nanoeigenpy.FullPivHouseholderQR(rows, cols)
 fullpiv_householder_qr = nanoeigenpy.FullPivHouseholderQR(A)
 
 fullpiv_householder_qr = nanoeigenpy.FullPivHouseholderQR(np.eye(rows, rows))
+assert fullpiv_householder_qr.isSurjective()
+assert fullpiv_householder_qr.isInjective()
+fullpiv_householder_qr.isInvertible()
+
 X = rng.random((rows, 20))
 assert fullpiv_householder_qr.absDeterminant() == 1.0
 assert fullpiv_householder_qr.logAbsDeterminant() == 0.0
@@ -34,14 +42,25 @@ Y = fullpiv_householder_qr.solve(X)
 assert (X == Y).all()
 assert fullpiv_householder_qr.rank() == rows
 
+x = rng.random(rows)
+y = fullpiv_householder_qr.solve(x)
+assert (x == y).all()
+
 fullpiv_householder_qr.setThreshold(1e-8)
 assert fullpiv_householder_qr.threshold() == 1e-8
 assert nanoeigenpy.is_approx(np.eye(rows, rows), fullpiv_householder_qr.inverse())
 
+assert fullpiv_householder_qr.maxPivot() == 1.0
+assert fullpiv_householder_qr.nonzeroPivots() == rows
+assert fullpiv_householder_qr.dimensionOfKernel() == 0
+
 # Test ColPivHouseholderQR decomposition
 colpiv_householder_qr = nanoeigenpy.ColPivHouseholderQR()
+assert colpiv_householder_qr.info() == nanoeigenpy.ComputationInfo.Success
 colpiv_householder_qr = nanoeigenpy.ColPivHouseholderQR(rows, cols)
+assert colpiv_householder_qr.info() == nanoeigenpy.ComputationInfo.Success
 colpiv_householder_qr = nanoeigenpy.ColPivHouseholderQR(A)
+assert colpiv_householder_qr.info() == nanoeigenpy.ComputationInfo.Success
 
 colpiv_householder_qr = nanoeigenpy.ColPivHouseholderQR(np.eye(rows, rows))
 X = rng.random((rows, 20))
@@ -56,10 +75,17 @@ colpiv_householder_qr.setThreshold(1e-8)
 assert colpiv_householder_qr.threshold() == 1e-8
 assert nanoeigenpy.is_approx(np.eye(rows, rows), colpiv_householder_qr.inverse())
 
+assert colpiv_householder_qr.maxPivot() == 1.0
+assert colpiv_householder_qr.nonzeroPivots() == rows
+assert colpiv_householder_qr.dimensionOfKernel() == 0
+
 # Test CompleteOrthogonalDecomposition
 cod = nanoeigenpy.CompleteOrthogonalDecomposition()
+assert cod.info() == nanoeigenpy.ComputationInfo.Success
 cod = nanoeigenpy.CompleteOrthogonalDecomposition(rows, cols)
+assert cod.info() == nanoeigenpy.ComputationInfo.Success
 cod = nanoeigenpy.CompleteOrthogonalDecomposition(A)
+assert cod.info() == nanoeigenpy.ComputationInfo.Success
 
 cod = nanoeigenpy.CompleteOrthogonalDecomposition(np.eye(rows, rows))
 X = rng.random((rows, 20))
@@ -70,6 +96,14 @@ Y = cod.solve(X)
 assert (X == Y).all()
 assert cod.rank() == rows
 
+x = rng.random(rows)
+y = cod.solve(x)
+assert (x == y).all()
+
 cod.setThreshold(1e-8)
 assert cod.threshold() == 1e-8
 assert nanoeigenpy.is_approx(np.eye(rows, rows), cod.pseudoInverse())
+
+assert cod.maxPivot() == 1.0
+assert cod.nonzeroPivots() == rows
+assert cod.dimensionOfKernel() == 0

--- a/tests/python/test_QR.py
+++ b/tests/python/test_QR.py
@@ -19,3 +19,57 @@ assert householder_qr_eye.logAbsDeterminant() == 0.0
 
 Y = householder_qr_eye.solve(X)
 assert (X == Y).all()
+
+# Test FullPivHouseholderQR decomposition
+fullpiv_householder_qr = nanoeigenpy.FullPivHouseholderQR()
+fullpiv_householder_qr = nanoeigenpy.FullPivHouseholderQR(rows, cols)
+fullpiv_householder_qr = nanoeigenpy.FullPivHouseholderQR(A)
+
+fullpiv_householder_qr = nanoeigenpy.FullPivHouseholderQR(np.eye(rows, rows))
+X = rng.random((rows, 20))
+assert fullpiv_householder_qr.absDeterminant() == 1.0
+assert fullpiv_householder_qr.logAbsDeterminant() == 0.0
+
+Y = fullpiv_householder_qr.solve(X)
+assert (X == Y).all()
+assert fullpiv_householder_qr.rank() == rows
+
+fullpiv_householder_qr.setThreshold(1e-8)
+assert fullpiv_householder_qr.threshold() == 1e-8
+assert nanoeigenpy.is_approx(np.eye(rows, rows), fullpiv_householder_qr.inverse())
+
+# Test ColPivHouseholderQR decomposition
+colpiv_householder_qr = nanoeigenpy.ColPivHouseholderQR()
+colpiv_householder_qr = nanoeigenpy.ColPivHouseholderQR(rows, cols)
+colpiv_householder_qr = nanoeigenpy.ColPivHouseholderQR(A)
+
+colpiv_householder_qr = nanoeigenpy.ColPivHouseholderQR(np.eye(rows, rows))
+X = rng.random((rows, 20))
+assert colpiv_householder_qr.absDeterminant() == 1.0
+assert colpiv_householder_qr.logAbsDeterminant() == 0.0
+
+Y = colpiv_householder_qr.solve(X)
+assert (X == Y).all()
+assert colpiv_householder_qr.rank() == rows
+
+colpiv_householder_qr.setThreshold(1e-8)
+assert colpiv_householder_qr.threshold() == 1e-8
+assert nanoeigenpy.is_approx(np.eye(rows, rows), colpiv_householder_qr.inverse())
+
+# Test CompleteOrthogonalDecomposition
+cod = nanoeigenpy.CompleteOrthogonalDecomposition()
+cod = nanoeigenpy.CompleteOrthogonalDecomposition(rows, cols)
+cod = nanoeigenpy.CompleteOrthogonalDecomposition(A)
+
+cod = nanoeigenpy.CompleteOrthogonalDecomposition(np.eye(rows, rows))
+X = rng.random((rows, 20))
+assert cod.absDeterminant() == 1.0
+assert cod.logAbsDeterminant() == 0.0
+
+Y = cod.solve(X)
+assert (X == Y).all()
+assert cod.rank() == rows
+
+cod.setThreshold(1e-8)
+assert cod.threshold() == 1e-8
+assert nanoeigenpy.is_approx(np.eye(rows, rows), cod.pseudoInverse())

--- a/tests/python/test_QR.py
+++ b/tests/python/test_QR.py
@@ -1,0 +1,21 @@
+import nanoeigenpy
+import numpy as np
+
+rows = 20
+cols = 100
+rng = np.random.default_rng()
+
+A = rng.random((rows, cols))
+
+# Test HouseholderQR decomposition
+householder_qr = nanoeigenpy.HouseholderQR()
+householder_qr = nanoeigenpy.HouseholderQR(rows, cols)
+householder_qr = nanoeigenpy.HouseholderQR(A)
+
+householder_qr_eye = nanoeigenpy.HouseholderQR(np.eye(rows, rows))
+X = rng.random((rows, 20))
+assert householder_qr_eye.absDeterminant() == 1.0
+assert householder_qr_eye.logAbsDeterminant() == 0.0
+
+Y = householder_qr_eye.solve(X)
+assert (X == Y).all()

--- a/tests/python/test_eigen_solver.py
+++ b/tests/python/test_eigen_solver.py
@@ -1,14 +1,59 @@
 import nanoeigenpy
 import numpy as np
 
-dim = 100
-rng = np.random.default_rng()
+dim = 4
+seed = 1
+rng = np.random.default_rng(seed)
+
 A = rng.random((dim, dim))
+print("A :")
+print(A)
 
+# Tests init
+es = nanoeigenpy.EigenSolver()
+#assert es.info() == nanoeigenpy.ComputationInfo.Success
+es = nanoeigenpy.EigenSolver(dim)
+#assert es.info() == nanoeigenpy.ComputationInfo.Success
 es = nanoeigenpy.EigenSolver(A)
+#assert es.info() == nanoeigenpy.ComputationInfo.Success
 
+# Test eigenvectors
+# Test eigenvalues
 V = es.eigenvectors()
 D = es.eigenvalues()
 
 assert nanoeigenpy.is_approx(A.dot(V).real, V.dot(np.diag(D)).real)
 assert nanoeigenpy.is_approx(A.dot(V).imag, V.dot(np.diag(D)).imag)
+
+# Test compute
+# Done implicitly at init
+
+# Test pseudoEigenvalueMatrix
+print("es.pseudoEigenvalueMatrix()")
+print(es.pseudoEigenvalueMatrix())
+
+# Test nb::init<>()
+# Test id
+es1 = nanoeigenpy.EigenSolver()
+es2 = nanoeigenpy.EigenSolver()
+
+id1 = es1.id()
+id2 = es2.id()
+
+assert id1 != id2
+assert id1 == es1.id()
+assert id2 == es2.id()
+
+# Test nb::init<Eigen::DenseIndex>()
+# Test id
+dim_constructor = 3
+
+es3 = nanoeigenpy.EigenSolver(dim_constructor)
+es4 = nanoeigenpy.EigenSolver(dim_constructor)
+
+id3 = es3.id()
+id4 = es4.id()
+
+assert id3 != id4
+assert id3 == es3.id()
+assert id4 == es4.id()

--- a/tests/python/test_eigen_solver.py
+++ b/tests/python/test_eigen_solver.py
@@ -1,0 +1,14 @@
+import nanoeigenpy
+import numpy as np
+
+dim = 100
+rng = np.random.default_rng()
+A = rng.random((dim, dim))
+
+es = nanoeigenpy.EigenSolver(A)
+
+V = es.eigenvectors()
+D = es.eigenvalues()
+
+assert nanoeigenpy.is_approx(A.dot(V).real, V.dot(np.diag(D)).real)
+assert nanoeigenpy.is_approx(A.dot(V).imag, V.dot(np.diag(D)).imag)

--- a/tests/python/test_ldlt.py
+++ b/tests/python/test_ldlt.py
@@ -2,45 +2,94 @@ import nanoeigenpy
 import numpy as np
 
 dim = 100
-rng = np.random.default_rng()
+seed = 1
+rng = np.random.default_rng(seed)
 
-
+# Test isNegative
 A_neg = -np.eye(dim)
 ldlt_neg = nanoeigenpy.LDLT(A_neg)
 assert ldlt_neg.isNegative() == True
 assert ldlt_neg.isPositive() == False
 
+# Test isPositive
 A_pos = np.eye(dim)
 ldlt_pos = nanoeigenpy.LDLT(A_pos)
 assert ldlt_pos.isPositive() == True
 assert ldlt_pos.isNegative() == False
 
-
+# Test nb::init<const MatrixType &>()
 A = rng.random((dim, dim))
 A = (A + A.T) * 0.5 + np.diag(10.0 + rng.random(dim))
 
 ldlt = nanoeigenpy.LDLT(A)
 
+# Test info
+assert ldlt.info() == nanoeigenpy.ComputationInfo.Success
 
+# Test matrixL
+# Test vector D
+# Test transpositionsP
 L = ldlt.matrixL()
 D = ldlt.vectorD()
 P = ldlt.transpositionsP()
 assert nanoeigenpy.is_approx(np.transpose(P).dot(L.dot(np.diag(D).dot(np.transpose(L).dot(P)))), A)
 
-
+# Test solve (matrix)
 X = rng.random((dim, 20))
 B = A.dot(X)
 X_est = ldlt.solve(B)
 assert nanoeigenpy.is_approx(X, X_est)
 assert nanoeigenpy.is_approx(A.dot(X_est), B)
 
+# Test solve (vector)
 x = rng.random(dim)
 b = A.dot(x)
 x_est = ldlt.solve(b)
-# assert nanoeigenpy.is_approx(x, x_est)             # not exposed yet for vectors
-# assert nanoeigenpy.is_approx(A.dot(x_est), b)      # not exposed yet for vectors
+assert nanoeigenpy.is_approx(x, x_est)            
+assert nanoeigenpy.is_approx(A.dot(x_est), b)    
 
+# Test reconstructedMatrix
+A_reconstructed = ldlt.reconstructedMatrix()
+assert nanoeigenpy.is_approx(A_reconstructed, A)
 
+# Test adjoint
+adjoint = ldlt.adjoint()
+assert adjoint is ldlt
+
+# Test rcond
+A_cond = np.eye(dim)
+ldlt_cond = nanoeigenpy.LDLT(A_cond)
+estimated_r_cond_num = ldlt_cond.rcond()
+assert abs(estimated_r_cond_num - 1) <= 1e-9
+
+# Test compute
+# Done implicitly at init
+
+# Test matrixLDLT
+LDLT = ldlt.matrixLDLT()
+LDLT_lower_without_diag = np.tril(LDLT, k=-1)
+L_lower_without_diag = np.tril(L, k=-1)
+assert nanoeigenpy.is_approx(LDLT_lower_without_diag, L_lower_without_diag)
+
+A_upper_without_diag = np.triu(A, k=1)  
+LLT_upper_without_diag = np.triu(LDLT, k=1)  
+assert nanoeigenpy.is_approx(A_upper_without_diag, LLT_upper_without_diag)
+
+LDLT_diag = np.diagonal(LDLT)
+assert nanoeigenpy.is_approx(LDLT_diag, D)
+
+# Test rankUpdate
+sigma = 3
+w = np.ones(dim)
+ldlt.rankUpdate(w, sigma)
+L = ldlt.matrixL()
+D = ldlt.vectorD()
+P = ldlt.transpositionsP()
+A_updated = np.transpose(P).dot(L.dot(np.diag(D).dot(np.transpose(L).dot(P))))
+assert nanoeigenpy.is_approx(A_updated, A + sigma * w * np.transpose(w))
+
+# Test nb::init<>()
+# Test id
 ldlt1 = nanoeigenpy.LDLT()
 ldlt2 = nanoeigenpy.LDLT()
 
@@ -51,3 +100,16 @@ assert id1 != id2
 assert id1 == ldlt1.id()
 assert id2 == ldlt2.id()
 
+# Test nb::init<Eigen::DenseIndex>()
+# Test id
+dim_constructor = 3
+
+ldlt3 = nanoeigenpy.LDLT(dim_constructor)
+ldlt4 = nanoeigenpy.LDLT(dim_constructor)
+
+id3 = ldlt3.id()
+id4 = ldlt4.id()
+
+assert id3 != id4
+assert id3 == ldlt3.id()
+assert id4 == ldlt4.id()

--- a/tests/python/test_llt.py
+++ b/tests/python/test_llt.py
@@ -2,41 +2,98 @@ import nanoeigenpy
 import numpy as np
 
 dim = 100
-rng = np.random.default_rng()
+seed = 1
+rng = np.random.default_rng(seed)
 
 A = rng.random((dim, dim))
 A = (A + A.T) * 0.5 + np.diag(10.0 + rng.random(dim))
 
+# Test nb::init<const MatrixType &>()
 llt = nanoeigenpy.LLT(A)
 
+# Test info
+assert llt.info() == nanoeigenpy.ComputationInfo.Success
 
+# Test matrixL
 L = llt.matrixL()
 assert nanoeigenpy.is_approx(L.dot(np.transpose(L)), A)
 
+# Test matrixU
 U = llt.matrixU()
 LU = L @ U
 assert nanoeigenpy.is_approx(LU, A)
 
-
+# Test solve (matrix)
 X = rng.random((dim, 20))
 B = A.dot(X)
 X_est = llt.solve(B)
 assert nanoeigenpy.is_approx(X, X_est)
 assert nanoeigenpy.is_approx(A.dot(X_est), B)
 
+# Test solve (vector)
 x = rng.random(dim)
 b = A.dot(x)
 x_est = llt.solve(b)
-# assert nanoeigenpy.is_approx(x, x_est)             # not exposed yet for vectors
-# assert nanoeigenpy.is_approx(A.dot(x_est), b)      # not exposed yet for vectors
+assert nanoeigenpy.is_approx(x, x_est)            
+assert nanoeigenpy.is_approx(A.dot(x_est), b)   
 
+# Test matrixLLT
+LLT = llt.matrixLLT()
+LLT_lower = np.tril(LLT)
+assert nanoeigenpy.is_approx(LLT_lower, L)
 
-ldlt1 = nanoeigenpy.LLT()
-ldlt2 = nanoeigenpy.LLT()
+A_upper = np.triu(A, k=1)  
+LLT_upper = np.triu(LLT, k=1)  
+assert nanoeigenpy.is_approx(A_upper, LLT_upper)
 
-id1 = ldlt1.id()
-id2 = ldlt2.id()
+# Test reconstructedMatrix
+A_reconstructed = llt.reconstructedMatrix()
+assert nanoeigenpy.is_approx(A_reconstructed, A)
+
+# Test adjoint
+adjoint = llt.adjoint()
+assert adjoint is llt
+
+# Test rcond
+A_cond = np.eye(dim)
+llt_cond = nanoeigenpy.LLT(A_cond)
+estimated_r_cond_num = llt_cond.rcond()
+assert abs(estimated_r_cond_num - 1) <= 1e-9
+
+# Test compute
+# Done implicitly at init
+
+# Test rankUpdate
+sigma = 3
+w = np.ones(dim)
+llt.rankUpdate(w, sigma)
+L = llt.matrixL()
+U = llt.matrixU()
+LU = L @ U
+assert nanoeigenpy.is_approx(LU, A + sigma * w * np.transpose(w))
+
+# Test nb::init<>()
+# Test id
+llt1 = nanoeigenpy.LLT()
+llt2 = nanoeigenpy.LLT()
+
+id1 = llt1.id()
+id2 = llt2.id()
 
 assert id1 != id2
-assert id1 == ldlt1.id()
-assert id2 == ldlt2.id()
+assert id1 == llt1.id()
+assert id2 == llt2.id()
+
+# Test nb::init<Eigen::DenseIndex>()
+# Test id
+dim_constructor = 3
+
+llt3 = nanoeigenpy.LLT(dim_constructor)
+llt4 = nanoeigenpy.LLT(dim_constructor)
+
+id3 = llt3.id()
+id4 = llt4.id()
+
+assert id3 != id4
+assert id3 == llt3.id()
+assert id4 == llt4.id()

--- a/tests/python/test_minres.py
+++ b/tests/python/test_minres.py
@@ -6,6 +6,7 @@ seed = 5
 rng = np.random.default_rng(seed)
 
 A = np.eye(dim)
+print("A :", A)
 minres = nanoeigenpy.MINRES(A)
 
 

--- a/tests/python/test_minres.py
+++ b/tests/python/test_minres.py
@@ -1,37 +1,38 @@
 import nanoeigenpy
 import numpy as np
 
-dim = 3
-seed = 3000
+dim = 2
+seed = 1
 rng = np.random.default_rng(seed)
 
 A = np.eye(dim)
 minres = nanoeigenpy.MINRES(A)
 
 
-X = rng.random((dim, 3))
+X = rng.random((dim, 2))
 B = A.dot(X)
-X_est = minres.solve(B)
-print("X :", X)
-print("X_est :", X_est)
-print("A.dot(X_est) :", A.dot(X_est))
-print("B :", B)
-# assert nanoeigenpy.is_approx(X, X_est, 1e-6)
-# assert nanoeigenpy.is_approx(A.dot(X_est), B, 1e-6)
 
-x = rng.random(dim)
-b = A.dot(x)
-x_est = minres.solve(b)
-# assert nanoeigenpy.is_approx(x, x_est)             # not exposed yet for vectors
-# assert nanoeigenpy.is_approx(A.dot(x_est), b)      # not exposed yet for vectors
+# X_est = minres.solve(B)
+# print("X :", X)
+# print("X_est :", X_est)
+# print("A.dot(X_est) :", A.dot(X_est))
+# print("B :", B)
+# # assert nanoeigenpy.is_approx(X, X_est, 1e-6)
+# # assert nanoeigenpy.is_approx(A.dot(X_est), B, 1e-6)
+
+# x = rng.random(dim)
+# b = A.dot(x)
+# x_est = minres.solve(b)
+# # assert nanoeigenpy.is_approx(x, x_est)             # not exposed yet for vectors
+# # assert nanoeigenpy.is_approx(A.dot(x_est), b)      # not exposed yet for vectors
 
 
-ldlt1 = nanoeigenpy.MINRES()
-ldlt2 = nanoeigenpy.MINRES()
+# ldlt1 = nanoeigenpy.MINRES()
+# ldlt2 = nanoeigenpy.MINRES()
 
-id1 = ldlt1.id()
-id2 = ldlt2.id()
+# id1 = ldlt1.id()
+# id2 = ldlt2.id()
 
-assert id1 != id2
-assert id1 == ldlt1.id()
-assert id2 == ldlt2.id()
+# assert id1 != id2
+# assert id1 == ldlt1.id()
+# assert id2 == ldlt2.id()

--- a/tests/python/test_minres.py
+++ b/tests/python/test_minres.py
@@ -2,7 +2,7 @@ import nanoeigenpy
 import numpy as np
 
 dim = 2
-seed = 1
+seed = 5
 rng = np.random.default_rng(seed)
 
 A = np.eye(dim)
@@ -12,11 +12,11 @@ minres = nanoeigenpy.MINRES(A)
 X = rng.random((dim, 2))
 B = A.dot(X)
 
-# X_est = minres.solve(B)
-# print("X :", X)
-# print("X_est :", X_est)
-# print("A.dot(X_est) :", A.dot(X_est))
-# print("B :", B)
+X_est = minres.solve(B)
+print("X :", X)
+print("X_est :", X_est)
+print("A.dot(X_est) :", A.dot(X_est))
+print("B :", B)
 # # assert nanoeigenpy.is_approx(X, X_est, 1e-6)
 # # assert nanoeigenpy.is_approx(A.dot(X_est), B, 1e-6)
 


### PR DESCRIPTION
is_approx: 
(?): Discussion with Wilson about keeping it or not 
=> Kept is, as coal uses a similar operator. Then we see later once we go to coal and others.

MatrixXs, and other customed types:
(?): Necessary ?
=> Quite used in eigenpy. Let is like this yet. 

About some methods lacking from an expose to another:
(?): Add them ?
=> They are not even in the source code in Eigen (for eg coinstruction with mem prealoc is in LLT, LDLT, but not MINRES). We expose what we can expose from Eigen source code.

About the return value policies, I do:
bp::return_self<>()  =>  nb::rv_policy::reference
bp::return_internal_reference<>()  =>   nb::rv_policy::reference_internal
bp::return_value_policy<bp::copy_const_reference>()  =>  nb::rv_policy::copy

About the tests:
Simple use of the exposed methods, can be upgraded if really needed